### PR TITLE
Fix CI tests by installing ansible-lint

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           python-version: '3.x'
       - name: Install test dependencies
-        run: pip3 install "${{ matrix.ansible }}" molecule molecule-docker
+        run: pip3 install "${{ matrix.ansible }}" molecule molecule-docker ansible-lint
       - name: Run Molecule tests
         run: molecule test --all
         env:

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ None.
 
 ## Development
 
-Running all tests (requires ansible, docker, molecule and molecule-docker to be installed).
+Running all tests (requires ansible, docker, molecule, molecule-docker and ansible-lint to be installed).
 
     molecule test --all
 


### PR DESCRIPTION
ansible-lint is not installed a dependency of `molecule` anymore so we have to install it explicitly