### PR TITLE
Workaround for PyYAML

### DIFF
--- a/requirements-molecule-ansible-2.9.txt
+++ b/requirements-molecule-ansible-2.9.txt
@@ -2,3 +2,4 @@ ansible-lint==5.4.0
 yamllint
 molecule==3.0.8
 molecule-docker
+pyyaml!=5.4.*,!=6.0.0  # These versions of pyyaml don't work with Cython 3, see https://github.com/yaml/pyyaml/issues/724


### PR DESCRIPTION
An older version of Molecule is required to work with Ansible 2.9 which in tern needs an older version of PyYAML. PyYAML 5.4.x and 6.0.0 don't work with Cython 3 (https://github.com/yaml/pyyaml/issues/724) so we have to explicitly exclude them to make the tests work again.