### PR TITLE
Drop support for old versions of Ubuntu and Ansible

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,46 +16,23 @@ jobs:
     strategy:
       matrix:
         distro:
+          - ubuntu:24.04
           - ubuntu:22.04
-          - ubuntu:20.04
         ansible:
           - ansible
-          - ansible==2.9.*
-
-    env:
-      WORKDIR: ${{ matrix.ansible == 'ansible==2.9.*' && 'giner.tfenv' }}
-
-    defaults:
-      run:
-        working-directory: ${{ env.WORKDIR }}  # https://github.com/ansible-community/molecule/pull/3409
+          - ansible==11.*
 
     steps:
       - name: Check out
         uses: actions/checkout@v4
-        with:
-          path: ${{ env.WORKDIR }}  # https://github.com/ansible-community/molecule/pull/3409
 
       - name: Set up Python 3
-        if: matrix.ansible != 'ansible==2.9.*'
         uses: actions/setup-python@v5
         with:
           python-version: '3.x'
 
-      - name: Set up Python 3 for Ansible 2.9
-        if: matrix.ansible == 'ansible==2.9.*'
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.11.x'
-
       - name: Install test dependencies
-        if: matrix.ansible != 'ansible==2.9.*'
         run: python3 -m pip install "${{ matrix.ansible }}" -Ur requirements-molecule.txt
-
-      - name: Install test dependencies for Ansible 2.9
-        if: matrix.ansible == 'ansible==2.9.*'
-        run: |
-          python3 -m pip install "${{ matrix.ansible }}" -Ur requirements-molecule-ansible-2.9.txt
-          ansible-galaxy collection install community.docker
 
       - name: Run Molecule tests
         run: molecule test --all

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: giner
   description: Install tfenv and Terraform into user's home or custom directory
   license: Apache-2.0
-  min_ansible_version: "2.9"
+  min_ansible_version: "11.0"
   platforms:
   - name: Ubuntu
     versions:

--- a/requirements-molecule-ansible-2.9.txt
+++ b/requirements-molecule-ansible-2.9.txt
@@ -1,5 +1,0 @@
-ansible-lint==5.4.0
-yamllint
-molecule==3.0.8
-molecule-docker
-pyyaml!=5.4.*,!=6.0.0  # These versions of pyyaml don't work with Cython 3, see https://github.com/yaml/pyyaml/issues/724


### PR DESCRIPTION
- Drop support for Ansible 2.9
- Drop support for Ubuntu 20.04
- Support Ansible >= 11.0
- Support Ubuntu 24.04 (in addition to 22.04)